### PR TITLE
update package.json homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "bugs": {
     "url": "https://github.com/PaicHyperionDev/hexo-generator-search/issues"
   },
-  "homepage": "https://github.com/hexojs/hexo-generator-search#readme",
+  "homepage": "https://github.com/PaicHyperionDev/hexo-generator-search#readme",
   "_npmVersion": "2.11.0",
   "_nodeVersion": "0.12.4",
   "_npmUser": {


### PR DESCRIPTION
It was going to a 404.

This patch enables `npm docs hexo-generator-search` to work.