### PR TITLE
use each or forEach to loop categories

### DIFF
--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -77,13 +77,11 @@ module.exports = function(locals){
                 }); 
                 temp_page.tags = tags 
             } 
-            if (page.categories && page.categories.length > 0) { 
-                var categories = new Array() 
-                var cate_index = 0 
-                page.categories.each(function (cate) {
-                    categories[cate_index] = cate.name; 
-                }); 
-                temp_page.categories = categories 
+            if (post.categories && post.categories.length > 0) {
+                temp_post.categories = []
+                (post.categories.each || post.categories.forEach)(function (item) {
+                    temp_post.categories.push(item)
+                });
             } 
             res[index] = temp_page;  
             index += 1; 


### PR DESCRIPTION
Sometimes I was getting an error looping through categories. It said `posts.categories` was an array in some cases and in other cases it was a [warehouse](/hexojs/warehouse) object.

This patch enables it to work if it is a warehouse object or `Array` object.