### PR TITLE
Conent optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ search:
   * `false` - generated results only cover title and other meta info without mainbody.
 - **template** (Optional) - path to a custom XML template
 - **strip_html** (Optional) - when `true` all HTML tags will be removed from the content.
+- **permalinks** (Optional) - when `true` the tags and categories in json output will also contain the permalinks.
 
 ## Exclude indexing
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ search:
 
 - **path** - file path. By default is `search.xml` . If the file extension is `.json`, the output format will be JSON. Otherwise XML format file will be exported.
 - **field** - the search scope you want to search, you can chose:
-  * **post** (Default) - will only covers all the posts of your blog.
-  * **page** - will only covers all the pages of your blog.
-  * **all** - will covers all the posts and pages of your blog.
-- **content** - whether contains the whole content of each article. If `false`, the generated results only cover title and other meta info without mainbody. By default is `true`.
+  * `post` (Default) - will only covers all the posts of your blog.
+  * `page` - will only covers all the pages of your blog.
+  * `all` - will covers all the posts and pages of your blog.
+- **content** - whether contains the whole content of each article.
+  * `true` (Default) - generated results use the mainbody.
+  * `rendered` - generated results use the rendered mainbody if available. (json only)
+  * `raw` - generated results use the raw mainbody if available. (json only, also contains the front-matter)
+  * `false` - generated results only cover title and other meta info without mainbody.
 - **template** (Optional) - path to a custom XML template
+- **strip_html** (Optional) - when `true` all HTML tags will be removed from the content.
 
 ## Exclude indexing
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ search:
 - **content** - whether contains the whole content of each article.
   * `true` (Default) - generated results use the mainbody.
   * `rendered` - generated results use the rendered mainbody if available. (json only)
+  * `excerpt` - generated results use the excerpts as content if available.
   * `raw` - generated results use the raw mainbody if available. (json only, also contains the front-matter)
   * `false` - generated results only cover title and other meta info without mainbody.
 - **template** (Optional) - path to a custom XML template

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ search:
   * `excerpt` - generated results use the excerpts as content if available.
   * `raw` - generated results use the raw mainbody if available. (json only, also contains the front-matter)
   * `false` - generated results only cover title and other meta info without mainbody.
+- **lang** (Optional) - when `true` the language of the post will be included in the output. This is useful for multilingual blogs. Defaults to the first language of the Hexo site, which is set in the root `_config.yml` file. (json only)
 - **ignore_regex** (Optional) - a regular expression to ignore certain files from being indexed. For example, you can use `'^.+\.(js|css)$'` to ignore all JavaScript and CSS files within the source folder. (json only)
 - **template** (Optional) - path to a custom XML template
 - **strip_html** (Optional) - when `true` all HTML tags will be removed from the content.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ search:
   * `excerpt` - generated results use the excerpts as content if available.
   * `raw` - generated results use the raw mainbody if available. (json only, also contains the front-matter)
   * `false` - generated results only cover title and other meta info without mainbody.
+- **ignore_regex** (Optional) - a regular expression to ignore certain files from being indexed. For example, you can use `'^.+\.(js|css)$'` to ignore all JavaScript and CSS files within the source folder. (json only)
 - **template** (Optional) - path to a custom XML template
 - **strip_html** (Optional) - when `true` all HTML tags will be removed from the content.
 - **permalinks** (Optional) - when `true` the tags and categories in json output will also contain the permalinks.

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -44,6 +44,9 @@ module.exports = function(locals){
             temp_post.title = post.title || 'No Title'
             if (post.path) {
                 temp_post.url = config.root + post.path
+                if (temp_post.url.startsWith('//')) { // Handle cases where the path starts with double slashes
+                    temp_post.url = config.root + temp_post.url.substring(2);
+                }
             }
             if (content != false) {
                 if (content == 'rendered' && post.content) {
@@ -91,6 +94,9 @@ module.exports = function(locals){
             temp_page.title = page.title || 'No Title'
             if (page.path) {
                 temp_page.url = config.root + page.path
+                if (temp_page.url.startsWith('//')) { // Handle cases where the path starts with double slashes
+                    temp_page.url = config.root + temp_page.url.substring(2);
+                }
             }
             if (content != false) {
                 if (content == 'rendered' && page.content) {

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -53,8 +53,8 @@ module.exports = function(locals){
                     temp_post.content = temp_post.content.replace(/<[^>]+>/g, '')
                 }
             }
+            temp_post.tags = [];
             if (post.tags && post.tags.length > 0) {
-                temp_post.tags = [];
                 post.tags.forEach(function (tag) {
                     if (permalinks) {
                         temp_post.tags.push([ tag.name, tag.permalink ]);
@@ -63,8 +63,8 @@ module.exports = function(locals){
                     }
                 });
             }
+            temp_post.categories = [];
             if (post.categories && post.categories.length > 0) {
-                temp_post.categories = [];
                 post.categories.forEach(function (cate) {
                     if (permalinks) {
                         temp_post.categories.push([ cate.name, cate.permalink ]);

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -6,6 +6,9 @@ module.exports = function(locals){
     var searchConfig = config.search;
     var searchfield = searchConfig.field;
     var content = searchConfig.content;
+    if (content == undefined) content = true;
+    var stripHtml = searchConfig.strip_html;
+    if (stripHtml == undefined) stripHtml = false;
 
     var posts, pages;
 
@@ -34,8 +37,17 @@ module.exports = function(locals){
             if (post.path) {
                 temp_post.url = config.root + post.path
             }
-            if (content != false && post._content) {
-                temp_post.content = post._content
+            if (content != false) {
+                if (content == 'rendered' && post.content) {
+                    temp_post.content = post.content
+                } else if (content == 'raw' && post.raw) {
+                    temp_post.content = post.raw
+                } else if (post._content) {
+                    temp_post.content = post._content
+                }
+                if (stripHtml) {
+                    temp_post.content = temp_post.content.replace(/<[^>]+>/g, '')
+                }
             }
             if (post.tags && post.tags.length > 0) {
                 var tags = [];
@@ -59,12 +71,21 @@ module.exports = function(locals){
         pages.each(function(page){
             if (page.indexing != undefined && !page.indexing) return;
             var temp_page = new Object()
-            temp_post.title = post.title || 'No Title'
+            temp_page.title = page.title || 'No Title'
             if (page.path) {
                 temp_page.url = config.root + page.path
             }
-            if (content != false && page._content) {
-                temp_page.content = page._content
+            if (content != false) {
+                if (content == 'rendered' && page.content) {
+                    temp_page.content = page.content
+                } else if (content == 'raw' && page.raw) {
+                    temp_page.content = page.raw
+                } else if (page._content) {
+                    temp_page.content = page._content
+                }
+                if (stripHtml) {
+                    temp_post.content = temp_post.content.replace(/<[^>]+>/g, '')
+                }
             }
             if (page.tags && page.tags.length > 0) {
                 var tags = new Array()

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -42,6 +42,8 @@ module.exports = function(locals){
             if (content != false) {
                 if (content == 'rendered' && post.content) {
                     temp_post.content = post.content
+                } else if (content == 'excerpt' && post.excerpt) {
+                    temp_post.content = post.excerpt
                 } else if (content == 'raw' && post.raw) {
                     temp_post.content = post.raw
                 } else if (post._content) {
@@ -86,6 +88,8 @@ module.exports = function(locals){
             if (content != false) {
                 if (content == 'rendered' && page.content) {
                     temp_page.content = page.content
+                } else if (content == 'excerpt' && page.excerpt) {
+                    temp_page.content = page.excerpt
                 } else if (content == 'raw' && page.raw) {
                     temp_page.content = page.raw
                 } else if (page._content) {

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -49,7 +49,7 @@ module.exports = function(locals){
                 } else if (post._content) {
                     temp_post.content = post._content
                 }
-                if (stripHtml) {
+                if (stripHtml && temp_post.content) {
                     temp_post.content = temp_post.content.replace(/<[^>]+>/g, '')
                 }
             }
@@ -95,8 +95,8 @@ module.exports = function(locals){
                 } else if (page._content) {
                     temp_page.content = page._content
                 }
-                if (stripHtml) {
-                    temp_post.content = temp_post.content.replace(/<[^>]+>/g, '')
+                if (stripHtml && temp_page.content) {
+                    temp_page.content = temp_page.content.replace(/<[^>]+>/g, '')
                 }
             }
             res[index] = temp_page;

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -12,6 +12,11 @@ module.exports = function(locals){
     var permalinks = searchConfig.permalinks;
     if (permalinks == undefined) permalinks = false;
 
+    var ignoreRegex = false;
+    if (typeof searchConfig.ignore_regex === 'string') {
+        ignoreRegex = new RegExp(searchConfig.ignore_regex);
+    }
+
     var posts, pages;
 
     if(searchfield.trim() != ''){
@@ -34,6 +39,7 @@ module.exports = function(locals){
     if(posts){
         posts.each(function(post) {
             if (post.indexing != undefined && !post.indexing) return;
+            if (ignoreRegex && ignoreRegex.test(post.path)) return;
             var temp_post = new Object()
             temp_post.title = post.title || 'No Title'
             if (post.path) {
@@ -80,6 +86,7 @@ module.exports = function(locals){
     if(pages){
         pages.each(function(page){
             if (page.indexing != undefined && !page.indexing) return;
+            if (ignoreRegex && ignoreRegex.test(page.path)) return;
             var temp_page = new Object()
             temp_page.title = page.title || 'No Title'
             if (page.path) {

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -11,6 +11,10 @@ module.exports = function(locals){
     if (stripHtml == undefined) stripHtml = false;
     var permalinks = searchConfig.permalinks;
     if (permalinks == undefined) permalinks = false;
+    var lang = searchConfig.lang;
+    if (lang == undefined) lang = false;
+    var defaultLang = config.language || 'en';
+    if (Array.isArray(defaultLang)) defaultLang = defaultLang[0]; // Use the first language in the array
 
     var ignoreRegex = false;
     if (typeof searchConfig.ignore_regex === 'string') {
@@ -47,6 +51,9 @@ module.exports = function(locals){
                 if (temp_post.url.startsWith('//')) { // Handle cases where the path starts with double slashes
                     temp_post.url = config.root + temp_post.url.substring(2);
                 }
+            }
+            if (lang) {
+                temp_post.lang = post.lang || defaultLang;
             }
             if (content != false) {
                 if (content == 'rendered' && post.content) {
@@ -97,6 +104,9 @@ module.exports = function(locals){
                 if (temp_page.url.startsWith('//')) { // Handle cases where the path starts with double slashes
                     temp_page.url = config.root + temp_page.url.substring(2);
                 }
+            }
+            if (lang) {
+                temp_page.lang = page.lang || defaultLang;
             }
             if (content != false) {
                 if (content == 'rendered' && page.content) {

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -9,6 +9,8 @@ module.exports = function(locals){
     if (content == undefined) content = true;
     var stripHtml = searchConfig.strip_html;
     if (stripHtml == undefined) stripHtml = false;
+    var permalinks = searchConfig.permalinks;
+    if (permalinks == undefined) permalinks = false;
 
     var posts, pages;
 
@@ -50,18 +52,24 @@ module.exports = function(locals){
                 }
             }
             if (post.tags && post.tags.length > 0) {
-                var tags = [];
+                temp_post.tags = [];
                 post.tags.forEach(function (tag) {
-                    tags.push(tag.name);
+                    if (permalinks) {
+                        temp_post.tags.push([ tag.name, tag.permalink ]);
+                    } else {
+                        temp_post.tags.push(tag.name);
+                    }
                 });
-                temp_post.tags = tags
             }
             if (post.categories && post.categories.length > 0) {
-                var categories = [];
+                temp_post.categories = [];
                 post.categories.forEach(function (cate) {
-                    categories.push(cate.name);
+                    if (permalinks) {
+                        temp_post.categories.push([ cate.name, cate.permalink ]);
+                    } else {
+                        temp_post.categories.push(cate.name);
+                    }
                 });
-                temp_post.categories = categories
             }
             res[index] = temp_post;
             index += 1;
@@ -88,17 +96,24 @@ module.exports = function(locals){
                 }
             }
             if (page.tags && page.tags.length > 0) {
-                var tags = new Array()
-                var tag_index = 0
+                temp_page.tags = [];
                 page.tags.each(function (tag) {
-                    tags[tag_index] = tag.name;
+                    if (permalinks) {
+                        temp_page.tags.push([ tag.name, tag.permalink ]);
+                    } else {
+                        temp_page.tags.push(tag.name);
+                    }
                 });
-                temp_page.tags = tags
             }
             if (page.categories && page.categories.length > 0) {
-                temp_page.categories = []
+                temp_page.categories = [];
                 (page.categories.each || page.categories.forEach)(function (item) {
                     temp_page.categories.push(item);
+                    if (permalinks) {
+                        temp_page.categories.push([item.name, item.permalink]);
+                    } else {
+                        temp_page.categories.push(item.name);
+                    }
                 });
             }
             res[index] = temp_page;

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -99,27 +99,6 @@ module.exports = function(locals){
                     temp_post.content = temp_post.content.replace(/<[^>]+>/g, '')
                 }
             }
-            if (page.tags && page.tags.length > 0) {
-                temp_page.tags = [];
-                page.tags.each(function (tag) {
-                    if (permalinks) {
-                        temp_page.tags.push([ tag.name, tag.permalink ]);
-                    } else {
-                        temp_page.tags.push(tag.name);
-                    }
-                });
-            }
-            if (page.categories && page.categories.length > 0) {
-                temp_page.categories = [];
-                (page.categories.each || page.categories.forEach)(function (item) {
-                    temp_page.categories.push(item);
-                    if (permalinks) {
-                        temp_page.categories.push([item.name, item.permalink]);
-                    } else {
-                        temp_page.categories.push(item.name);
-                    }
-                });
-            }
             res[index] = temp_page;
             index += 1;
         });

--- a/lib/json_generator.js
+++ b/lib/json_generator.js
@@ -23,67 +23,67 @@ module.exports = function(locals){
         posts = locals.posts.sort('-date');
     }
 
-    var res = new Array() 
+    var res = new Array()
     var index = 0
-    
-    if(posts){     
+
+    if(posts){
         posts.each(function(post) {
             if (post.indexing != undefined && !post.indexing) return;
-            var temp_post = new Object() 
+            var temp_post = new Object()
             temp_post.title = post.title || 'No Title'
-            if (post.path) { 
-                temp_post.url = config.root + post.path 
-            } 
-            if (content != false && post._content) { 
-                temp_post.content = post._content 
-            } 
-            if (post.tags && post.tags.length > 0) { 
+            if (post.path) {
+                temp_post.url = config.root + post.path
+            }
+            if (content != false && post._content) {
+                temp_post.content = post._content
+            }
+            if (post.tags && post.tags.length > 0) {
                 var tags = [];
                 post.tags.forEach(function (tag) {
                     tags.push(tag.name);
-                }); 
-                temp_post.tags = tags 
-            } 
-            if (post.categories && post.categories.length > 0) { 
+                });
+                temp_post.tags = tags
+            }
+            if (post.categories && post.categories.length > 0) {
                 var categories = [];
                 post.categories.forEach(function (cate) {
                     categories.push(cate.name);
-                }); 
-                temp_post.categories = categories 
-            } 
-            res[index] = temp_post;  
-            index += 1; 
-	    }); 
-    } 
-    if(pages){ 
+                });
+                temp_post.categories = categories
+            }
+            res[index] = temp_post;
+            index += 1;
+	    });
+    }
+    if(pages){
         pages.each(function(page){
             if (page.indexing != undefined && !page.indexing) return;
-            var temp_page = new Object() 
+            var temp_page = new Object()
             temp_post.title = post.title || 'No Title'
-            if (page.path) { 
-                temp_page.url = config.root + page.path 
-            } 
-            if (content != false && page._content) { 
-                temp_page.content = page._content 
-            } 
-            if (page.tags && page.tags.length > 0) { 
-                var tags = new Array() 
-                var tag_index = 0 
+            if (page.path) {
+                temp_page.url = config.root + page.path
+            }
+            if (content != false && page._content) {
+                temp_page.content = page._content
+            }
+            if (page.tags && page.tags.length > 0) {
+                var tags = new Array()
+                var tag_index = 0
                 page.tags.each(function (tag) {
-                    tags[tag_index] = tag.name; 
-                }); 
-                temp_page.tags = tags 
-            } 
+                    tags[tag_index] = tag.name;
+                });
+                temp_page.tags = tags
+            }
             if (page.categories && page.categories.length > 0) {
                 temp_page.categories = []
                 (page.categories.each || page.categories.forEach)(function (item) {
                     temp_page.categories.push(item);
                 });
-            } 
-            res[index] = temp_page;  
-            index += 1; 
-        }); 
-    } 
+            }
+            res[index] = temp_page;
+            index += 1;
+        });
+    }
 
 
     var json = JSON.stringify(res);

--- a/lib/xml_generator.js
+++ b/lib/xml_generator.js
@@ -22,7 +22,9 @@ module.exports = function(locals){
   var template = searchTmpl;
   var searchfield = searchConfig.field;
   var content = searchConfig.content;
-  if (content == undefined) content=true;
+  if (content == undefined) content = true;
+  var stripHtml = searchConfig.strip_html;
+  if (stripHtml == undefined) stripHtml = false;
 
   var posts, pages;
 
@@ -38,6 +40,15 @@ module.exports = function(locals){
     }
   }else{
     posts = locals.posts.sort('-date');
+  }
+
+  if (stripHtml) {
+    posts.data.forEach(function (p) {
+      p.content = p.content.replace(/<[^>]+>/g, '');
+    });
+    pages.data.forEach(function (p) {
+      p.content = p.content.replace(/<[^>]+>/g, '');
+    });
   }
 
   var rootURL;

--- a/lib/xml_generator.js
+++ b/lib/xml_generator.js
@@ -57,10 +57,14 @@ module.exports = function(locals){
 
   if (stripHtml) {
     posts.data.forEach(function (p) {
-      p.content = p.content.replace(/<[^>]+>/g, '');
+      if (p.content) {
+        p.content = p.content.replace(/<[^>]+>/g, '');
+      }
     });
     pages.data.forEach(function (p) {
-      p.content = p.content.replace(/<[^>]+>/g, '');
+      if (p.content) {
+        p.content = p.content.replace(/<[^>]+>/g, '');
+      }
     });
   }
 

--- a/lib/xml_generator.js
+++ b/lib/xml_generator.js
@@ -42,6 +42,19 @@ module.exports = function(locals){
     posts = locals.posts.sort('-date');
   }
 
+  if (content == 'excerpt') {
+    posts.data.forEach(function (p) {
+      if (p.excerpt) {
+        p.content = p.excerpt;
+      }
+    });
+    pages.data.forEach(function (p) {
+      if (p.excerpt) {
+        p.content = p.excerpt;
+      }
+    });
+  }
+
   if (stripHtml) {
     posts.data.forEach(function (p) {
       p.content = p.content.replace(/<[^>]+>/g, '');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-search",
-  "version": "2.4.3",
+  "version": "2.4.3-crycode.1",
   "description": "Seach generator plugin for Hexo",
   "main": "index",
   "directories": {


### PR DESCRIPTION
* Added `content` options:
  * `rendered` - generated results use the rendered mainbody if available. (json only)
  * `excerpt` - generated results use the excerpts as content if available.
  * `raw` - generated results use the raw mainbody if available. (json only, also contains the front-matter)
* Added `strip_html` option to strip out all html tags.
* Added `permalinks` option to include permalinks for tags and categories in json output.
* Removed tags and categories code for pages in json_generator since pages doesn't support tags/categories.
* Always include `tags` and `categories` array in json output.  
  If posts have no tags/categories the keys where omitted in the json output. If we always include them (even if empty) we get  a more reliable json structure which is easier to parse.

This PR will close #54 and close #68.
